### PR TITLE
Change the column width ratio in BOK topic pages

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -96,5 +96,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/src/app/bok/bok.component.html
+++ b/src/app/bok/bok.component.html
@@ -32,12 +32,12 @@
 
 </section>
 <section style=" padding: 10px;">
-  <mat-grid-list cols="2"> <!--  rowHeight="fit" -->
-    <mat-grid-tile class="block">
+  <mat-grid-list cols="12"> <!--  rowHeight="fit" -->
+    <mat-grid-tile colspan="4" class="block">
       <div id="graph"></div>
     </mat-grid-tile>
 
-    <mat-grid-tile class="block section">
+    <mat-grid-tile colspan="8" class="block section">
       <cdk-virtual-scroll-viewport scrollWindow itemSize="70" style="padding-right: 15px"> <!-- && isConceptInfo -->
         <span *ngIf="resultNodes.length>0 && textInfo.innerHTML.length > 15" class="small"> <a
             (click)="cleanConceptInfo()" style="color: #007bff; font-weight: 400; cursor: pointer;"> <i


### PR DESCRIPTION
Change the column widths to 4 for the interactive graph and 8 for the content. #1 
![Screenshot 2024-10-21 at 2 16 23 PM](https://github.com/user-attachments/assets/2840be39-d105-46e4-8861-d0e8a60e4f14)
